### PR TITLE
MNT: remove codecov after security breach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ script:
 
 after_success:
   - coverage report -m
-  - codecov
 
   - |
     if [[ "$CONDA_UPLOAD" == "1" ]]; then

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
-codecov
 coverage
 flake8
 pytest


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove codecov. We aren't using it and they had a security breach